### PR TITLE
Fix gcloud deploy ZIP timestamp error by fully ignoring Scheduler Bot…

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -18,9 +18,10 @@ env.yaml
 venv/
 ENV/
 
-# IDE
+# IDE / Tools
 .idea/
 .vscode/
+.claude/
 *.swp
 *.swo
 
@@ -44,12 +45,8 @@ docs/
 ~$*.xlsx
 ~$*.xls
 
-# Data files (uploaded via UI, not bundled)
-Scheduler Bot Info/*.xlsx
-Scheduler Bot Info/*.xls
-Scheduler Bot Info/*.pdf
-Scheduler Bot Info/*.XLSX
-Scheduler Bot Info/*.XLS
+# Reference data files (uploaded via UI, not bundled)
+Scheduler Bot Info/
 
 # Output files
 outputs/*.xlsx


### PR DESCRIPTION
… Info/

The partial extension-based exclusions were not catching all reference files with pre-1980 timestamps. Excluding the entire directory since these files are uploaded via the UI at runtime, not bundled in the container.

https://claude.ai/code/session_01BcBrvc1LHCjUCY3P5WmTXg