### PR TITLE
Build MVP 1.8: role normalization, Days Idle column, resource utiliza…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ When the project owner says "deploy", "merge and deploy", "push to production", 
 
 ## Versioning Protocol (MANDATORY for production releases)
 
-**Current Version:** MVP 1.7
+**Current Version:** MVP 1.8
 
 When merging changes to `master` that will be deployed to production, you MUST:
 

--- a/backend/algorithms/des_scheduler.py
+++ b/backend/algorithms/des_scheduler.py
@@ -562,6 +562,9 @@ class PartState:
     # Planned resources
     planned_desma: Optional[str] = None  # Which Desma machine is assigned
 
+    # Days idle (from Shop Dispatch "Elapsed Days")
+    days_idle: Optional[int] = None
+
     # Priority tier
     priority: str = 'Normal'  # Hot-ASAP, Hot-Dated, Rework, Normal, CAVO
 
@@ -1084,7 +1087,8 @@ class DESScheduler:
                     serial_number=order.get('serial_number'),
                     priority=order.get('priority', 'Normal'),
                     special_instructions=order.get('special_instructions'),
-                    supermarket_location=order.get('supermarket_location')
+                    supermarket_location=order.get('supermarket_location'),
+                    days_idle=order.get('days_idle')
                 )
 
                 self.parts[part_id] = part_state
@@ -1382,7 +1386,8 @@ class DESScheduler:
                 priority=part.priority,
                 serial_number=part.serial_number,
                 special_instructions=part.special_instructions,
-                supermarket_location=part.supermarket_location
+                supermarket_location=part.supermarket_location,
+                days_idle=part.days_idle
             )
 
             self.scheduled_orders.append(scheduled)

--- a/backend/algorithms/scheduler.py
+++ b/backend/algorithms/scheduler.py
@@ -229,6 +229,7 @@ class ScheduledOrder:
     serial_number: str = None  # From Sales Order report
     special_instructions: str = None  # From redline requests
     supermarket_location: str = None  # From DCP report
+    days_idle: int = None  # From Shop Dispatch "Elapsed Days" (9999→0)
 
 
 @dataclass

--- a/backend/exporters/__init__.py
+++ b/backend/exporters/__init__.py
@@ -10,11 +10,13 @@ from .excel_exporter import (
     export_all_reports
 )
 from .impact_analysis_exporter import generate_impact_analysis
+from .resource_utilization_exporter import export_resource_utilization
 
 __all__ = [
     'export_master_schedule',
     'export_blast_schedule',
     'export_core_schedule',
     'export_all_reports',
-    'generate_impact_analysis'
+    'generate_impact_analysis',
+    'export_resource_utilization'
 ]

--- a/backend/exporters/excel_exporter.py
+++ b/backend/exporters/excel_exporter.py
@@ -43,6 +43,7 @@ def export_master_schedule(scheduled_orders: List, output_path: str) -> str:
             'Basic Finish Date': getattr(order, 'basic_finish_date', None),
             'Promise Date': order.promise_date,
             'On-Time': 'Yes' if order.on_time else 'No',
+            'Days Idle': getattr(order, 'days_idle', None) if getattr(order, 'days_idle', None) is not None else '',
             'Special Instructions': getattr(order, 'special_instructions', '') or ''
         })
 

--- a/backend/exporters/resource_utilization_exporter.py
+++ b/backend/exporters/resource_utilization_exporter.py
@@ -1,0 +1,151 @@
+"""
+Resource Utilization Exporter
+Generates per-station and per-machine utilization metrics from scheduled orders.
+"""
+
+import pandas as pd
+from collections import defaultdict
+from datetime import datetime
+from typing import List, Dict, Any
+
+
+def export_resource_utilization(scheduled_orders: List, output_path: str) -> str:
+    """
+    Export resource utilization report to Excel.
+
+    Calculates per-station and per-injection-machine utilization from
+    the operation history of scheduled orders.
+
+    Args:
+        scheduled_orders: List of ScheduledOrder objects with operations
+        output_path: Path for output Excel file
+
+    Returns:
+        Path to the created file
+    """
+    if not scheduled_orders:
+        # Write an empty report
+        pd.DataFrame().to_excel(output_path, index=False)
+        return output_path
+
+    # Determine simulation time span from earliest start to latest end
+    all_starts = []
+    all_ends = []
+    for order in scheduled_orders:
+        for op in order.operations:
+            if op.start_time:
+                all_starts.append(op.start_time)
+            if op.end_time:
+                all_ends.append(op.end_time)
+
+    if not all_starts or not all_ends:
+        pd.DataFrame().to_excel(output_path, index=False)
+        return output_path
+
+    sim_start = min(all_starts)
+    sim_end = max(all_ends)
+    total_span_hours = (sim_end - sim_start).total_seconds() / 3600
+
+    if total_span_hours <= 0:
+        pd.DataFrame().to_excel(output_path, index=False)
+        return output_path
+
+    # --- Station-level utilization ---
+    # Group operations by station name
+    station_ops = defaultdict(list)
+    for order in scheduled_orders:
+        for op in order.operations:
+            station_ops[op.operation_name].append(op)
+
+    station_rows = []
+    for station_name, ops in station_ops.items():
+        processing_hours = sum(op.cycle_time for op in ops)
+        op_count = len(ops)
+
+        # Sort by start_time to find gaps (idle periods) on this station
+        sorted_ops = sorted(ops, key=lambda o: o.start_time)
+
+        # For stations with individual resource_ids (injection machines),
+        # we'll handle them separately below — here we aggregate the station total
+        station_rows.append({
+            'Station': station_name,
+            'Resource': '(all)',
+            'Orders Processed': op_count,
+            'Total Processing Hours': round(processing_hours, 2),
+            'Available Hours': round(total_span_hours, 2),
+            'Utilization %': round((processing_hours / total_span_hours) * 100, 1),
+            'Idle Hours': round(total_span_hours - processing_hours, 2),
+        })
+
+    # --- Injection machine-level utilization ---
+    machine_ops = defaultdict(list)
+    for order in scheduled_orders:
+        for op in order.operations:
+            if op.resource_id:
+                machine_ops[op.resource_id].append(op)
+
+    machine_rows = []
+    for machine_id, ops in sorted(machine_ops.items()):
+        sorted_ops = sorted(ops, key=lambda o: o.start_time)
+        processing_hours = sum(op.cycle_time for op in sorted_ops)
+        op_count = len(sorted_ops)
+
+        # Estimate setup/changeover time from gaps between consecutive operations
+        # on the same machine (gaps shorter than 2 hours are likely changeover)
+        setup_hours = 0.0
+        for i in range(1, len(sorted_ops)):
+            gap = (sorted_ops[i].start_time - sorted_ops[i - 1].end_time).total_seconds() / 3600
+            if 0 < gap <= 2.0:
+                setup_hours += gap
+
+        utilized_hours = processing_hours + setup_hours
+        idle_hours = total_span_hours - utilized_hours
+
+        machine_rows.append({
+            'Station': 'INJECTION',
+            'Resource': machine_id,
+            'Orders Processed': op_count,
+            'Total Processing Hours': round(processing_hours, 2),
+            'Setup/Changeover Hours': round(setup_hours, 2),
+            'Available Hours': round(total_span_hours, 2),
+            'Utilization %': round((utilized_hours / total_span_hours) * 100, 1),
+            'Idle Hours': round(max(idle_hours, 0), 2),
+        })
+
+    # Build DataFrames
+    station_df = pd.DataFrame(station_rows)
+    # Sort by utilization descending
+    if not station_df.empty:
+        station_df = station_df.sort_values('Utilization %', ascending=False)
+
+    machine_df = pd.DataFrame(machine_rows)
+    if not machine_df.empty:
+        machine_df = machine_df.sort_values('Utilization %', ascending=False)
+
+    # Write to Excel with two sheets
+    with pd.ExcelWriter(output_path, engine='openpyxl') as writer:
+        station_df.to_excel(writer, sheet_name='Station Utilization', index=False)
+        machine_df.to_excel(writer, sheet_name='Machine Utilization', index=False)
+
+        from openpyxl.utils import get_column_letter
+
+        # Format Station Utilization sheet
+        ws_station = writer.sheets['Station Utilization']
+        for idx, col in enumerate(station_df.columns):
+            col_data = station_df[col].fillna('').astype(str)
+            max_data_len = col_data.str.len().max() if len(col_data) > 0 else 0
+            max_length = max(max_data_len, len(col)) + 2
+            ws_station.column_dimensions[get_column_letter(idx + 1)].width = min(max_length, 30)
+        ws_station.freeze_panes = 'A2'
+
+        # Format Machine Utilization sheet
+        ws_machine = writer.sheets['Machine Utilization']
+        for idx, col in enumerate(machine_df.columns):
+            col_data = machine_df[col].fillna('').astype(str)
+            max_data_len = col_data.str.len().max() if len(col_data) > 0 else 0
+            max_length = max(max_data_len, len(col)) + 2
+            ws_machine.column_dimensions[get_column_letter(idx + 1)].width = min(max_length, 30)
+        ws_machine.freeze_panes = 'A2'
+
+    print(f"[OK] Resource utilization report exported to: {output_path}")
+    return output_path

--- a/backend/parsers/shop_dispatch_parser.py
+++ b/backend/parsers/shop_dispatch_parser.py
@@ -104,7 +104,8 @@ def parse_shop_dispatch(filepath: str, sheet_name: str = 'Sheet1') -> tuple[List
                     'remaining_work_centers': row.get('Remaining Work Centers') if pd.notna(row.get('Remaining Work Centers')) else None,
                     'operation_quantity': row.get('Operation Quantity') if pd.notna(row.get('Operation Quantity')) else None,
                     'priority': row.get('Priority') if pd.notna(row.get('Priority')) else None,
-                    'elapsed_days': row.get('Elapsed Days') if pd.notna(row.get('Elapsed Days')) else None,
+                    'days_idle': 0 if (pd.notna(row.get('Elapsed Days')) and row.get('Elapsed Days') == 9999)
+                                  else (int(row.get('Elapsed Days')) if pd.notna(row.get('Elapsed Days')) else None),
                     'source': 'Shop Dispatch',
                     'is_rework': is_rework,
                     'rework_lead_time_hours': rework_lead_time_hours

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -173,7 +173,7 @@
         <div class="container-fluid">
             <a class="navbar-brand" href="/">
                 <i class="bi bi-calendar-check"></i> EstradaBot
-                <span class="badge bg-info ms-1" style="font-size: 0.55rem; vertical-align: middle;">MVP 1.7</span>
+                <span class="badge bg-info ms-1" style="font-size: 0.55rem; vertical-align: middle;">MVP 1.8</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>

--- a/backend/templates/reports.html
+++ b/backend/templates/reports.html
@@ -52,6 +52,14 @@
             </div>
         </div>
     </div>
+    <div class="col-md-4 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title"><i class="bi bi-bar-chart-line text-secondary"></i> Resource Utilization</h5>
+                <p class="card-text text-muted small">Per-station and per-machine utilization metrics. Shows processing hours, idle time, and utilization percentage.</p>
+            </div>
+        </div>
+    </div>
 </div>
 
 <!-- Available Reports Table -->
@@ -88,6 +96,8 @@
                             <i class="bi bi-hourglass-split text-info"></i>
                         {% elif report.type == 'Impact Analysis' %}
                             <i class="bi bi-graph-up text-success"></i>
+                        {% elif report.type == 'Resource Utilization' %}
+                            <i class="bi bi-bar-chart-line text-secondary"></i>
                         {% else %}
                             <i class="bi bi-file-earmark-excel text-secondary"></i>
                         {% endif %}
@@ -126,7 +136,7 @@
     </div>
     <div class="card-body">
         <div class="row">
-            {% set report_types = ['Master Schedule', 'BLAST Schedule', 'Core Oven Schedule', 'Pending Core Report', 'Impact Analysis'] %}
+            {% set report_types = ['Master Schedule', 'BLAST Schedule', 'Core Oven Schedule', 'Pending Core Report', 'Impact Analysis', 'Resource Utilization'] %}
             {% for type in report_types %}
                 {% set latest = reports|selectattr('type', 'equalto', type)|first %}
                 <div class="col-md-4 mb-2">

--- a/backend/templates/update_log.html
+++ b/backend/templates/update_log.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h2><i class="bi bi-journal-text"></i> Update Log</h2>
-    <span class="badge bg-info fs-6">Current Version: MVP 1.7</span>
+    <span class="badge bg-info fs-6">Current Version: MVP 1.8</span>
 </div>
 
 <!-- Feedback Form -->
@@ -97,6 +97,28 @@
         <i class="bi bi-clock-history"></i> Version History
     </div>
     <div class="card-body">
+        <!-- MVP 1.8 -->
+        <div class="mb-4">
+            <h5>
+                <span class="badge bg-info">MVP 1.8</span>
+                <small class="text-muted ms-2">February 2026 - Quick Wins &amp; Reporting</small>
+            </h5>
+            <ul class="list-group list-group-flush">
+                <li class="list-group-item">
+                    <i class="bi bi-check-circle text-success"></i>
+                    <strong>Role Name Normalization:</strong> Standardized <code>customer_service</code> role name across the codebase, eliminating the inconsistency between <code>customer_service</code> and <code>customerservice</code> variants. Tech debt cleanup ahead of RBAC work in MVP 1.10.
+                </li>
+                <li class="list-group-item">
+                    <i class="bi bi-check-circle text-success"></i>
+                    <strong>Days Idle Column:</strong> Added "Days Idle" column to the Master Schedule export. Sourced from Shop Dispatch "Elapsed Days" field with automatic 9999 &rarr; 0 conversion. Helps identify orders sitting idle in work-in-process.
+                </li>
+                <li class="list-group-item">
+                    <i class="bi bi-check-circle text-success"></i>
+                    <strong>Resource Utilization Report:</strong> New Excel export with per-station and per-injection-machine utilization metrics. Includes processing hours, idle hours, setup/changeover hours, and utilization percentage. Available on the Reports page.
+                </li>
+            </ul>
+        </div>
+
         <!-- MVP 1.7 -->
         <div class="mb-4">
             <h5>

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -47,9 +47,9 @@ Agreed Feb 15, 2026. Items moved from old MVP 2.0 plan, split into 3 focused rel
 
 | Item | Status | Notes |
 |------|--------|-------|
-| Role name normalization | Not started | Fix `customer_service` vs `customerservice` — tech debt cleanup before RBAC |
-| Resource utilization report | Not started | Per-operation/machine utilization metrics |
-| Days Idle column | Not started | From Shop Dispatch "Elapsed Days"; 9999→0 rule |
+| Role name normalization | Complete | Fix `customer_service` vs `customerservice` — tech debt cleanup before RBAC |
+| Resource utilization report | Complete | Per-station/machine utilization Excel export with two sheets |
+| Days Idle column | Complete | From Shop Dispatch "Elapsed Days"; 9999→0 rule, added to Master Schedule export |
 
 ### MVP 1.9 — Simulation power
 


### PR DESCRIPTION
…tion report

- Normalize role names: standardize on `customer_service` (remove `customerservice` variant)
- Add Days Idle column to Master Schedule export, sourced from Shop Dispatch "Elapsed Days" field with 9999→0 conversion rule
- New resource utilization exporter with per-station and per-injection-machine metrics (processing hours, idle hours, setup/changeover, utilization %)
- Wire utilization report into both schedule generation and planner final export
- Add Resource Utilization card and download link to Reports page
- Complete versioning protocol: bump to MVP 1.8, update log, CLAUDE.md

https://claude.ai/code/session_01BAdYPa5d9hyDzgMWtmAPtM