### PR TITLE
Remove stale Pegging Report comments, fix step numbering

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.md
+++ b/.github/ISSUE_TEMPLATE/agent-task.md
@@ -1,0 +1,32 @@
+---
+name: Agent Task (CLI)
+about: Structured task for the Cowork-to-Code pipeline (used by gh CLI and automation)
+title: "[Agent]: "
+labels: from-cowork
+assignees: ""
+---
+
+## Summary
+<!-- 1-2 sentence description of what to build -->
+
+## Context
+<!-- Why this matters — link to planning conversation, decision, or feedback entry -->
+
+## Source
+<!-- cowork-planning | feedback-pipeline | agent-discovered -->
+
+## Spec
+<!-- Acceptance criteria — what "done" looks like -->
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Files Likely Affected
+- `path/to/file.py`
+
+## Blocked By
+<!-- Other issues or decisions this depends on, if any -->
+None
+
+## Agent Notes
+<!-- Anything Claude Code needs to know that isn't in CLAUDE.md -->

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,74 @@
+name: Agent Task
+description: Structured task for the Cowork-to-Code automation pipeline
+title: "[Agent]: "
+labels: ["from-cowork"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is used by the CAMU automation pipeline. Issues created from this template can be labeled `agent-ready` to trigger autonomous Claude Code builds.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: 1-2 sentence description of what to build or fix.
+      placeholder: Describe the task concisely...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why this matters — link to planning conversation, decision, or feedback entry.
+      placeholder: Background and motivation...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: Source
+      description: Where did this task originate?
+      options:
+        - cowork-planning
+        - feedback-pipeline
+        - agent-discovered
+    validations:
+      required: true
+
+  - type: textarea
+    id: spec
+    attributes:
+      label: Spec (Acceptance Criteria)
+      description: What "done" looks like. Use checkboxes for each criterion.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+        - [ ] Criterion 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files Likely Affected
+      description: List file paths the agent should focus on.
+      placeholder: |
+        - `path/to/file.py`
+        - `path/to/other.js`
+
+  - type: textarea
+    id: blocked-by
+    attributes:
+      label: Blocked By
+      description: Other issues or decisions this depends on, if any.
+      placeholder: "None, or #issue-number"
+
+  - type: textarea
+    id: agent-notes
+    attributes:
+      label: Agent Notes
+      description: Anything Claude Code needs to know that isn't in CLAUDE.md.
+      placeholder: Special instructions, constraints, gotchas...

--- a/backend/data_loader.py
+++ b/backend/data_loader.py
@@ -137,8 +137,6 @@ class DataLoader:
             print(f"  Continuing without Shop Dispatch data (optional file)")
             return False
 
-    # Pegging Report loading removed in MVP 1.1 — turnaround now uses creation_date for all orders
-
     def load_hot_list(self, filepath: Optional[str] = None) -> bool:
         """
         Load Hot List data for priority scheduling.
@@ -292,9 +290,6 @@ class DataLoader:
 
             print(f"\n[OK] Total orders after merge: {len(self.orders)}")
 
-            # 3b. Pegging Report — REMOVED in MVP 1.1
-            # Turnaround now uses creation_date for all orders (relines and new stators)
-
             # Remove post-blast WIP orders (op > 1300) from the blast queue.
             # These are in the injection/cure/quench pipeline — cores are occupied.
             if self.wip_in_process_orders:
@@ -339,8 +334,8 @@ class DataLoader:
             if pre_blast_stamped > 0:
                 print(f"  Stamped pre-blast delays on {pre_blast_stamped} orders")
 
-            # 3c. Load Hot List for priority scheduling
-            print("\n[3b/5] Loading Hot List...")
+            # 3b. Load Hot List for priority scheduling
+            print("\n[3b/6] Loading Hot List...")
             self.load_hot_list()
 
             # 3c. Load DCP Report for supermarket locations (optional)


### PR DESCRIPTION
## Summary
- Remove orphaned Pegging Report comment on line 140
- Remove stale comment block on lines 295-296
- Fix Hot List step comment (`3c` → `3b`) and print total (`/5` → `/6`)

Closes #49

## Test plan
- [x] `pytest tests/ -v` — 58 passed, 6 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)