### PR TITLE
Fix feedback status not showing as Fixed in My Feedback

### DIFF
--- a/backend/templates/update_log.html
+++ b/backend/templates/update_log.html
@@ -1000,6 +1000,7 @@
         .then(data => {
             if (data.success) {
                 loadFeedback();
+                loadMyFeedback();
             } else {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,6 +88,27 @@ class TestFeedbackEndpoints:
         data = response.get_json()
         assert data['success'] is True
 
+    def test_update_feedback_status_visible_in_mine(self, auth_client):
+        """Status change by admin should be visible in /api/feedback/mine."""
+        # Submit feedback
+        auth_client.post('/api/feedback', json={
+            'category': 'Bug Report',
+            'priority': 'Low',
+            'message': 'Fix visibility test'
+        })
+        # Update status to Fixed (index 0 = newest in reversed list)
+        response = auth_client.put('/api/feedback/0/status', json={
+            'status': 'Fixed'
+        })
+        assert response.get_json()['success'] is True
+
+        # Verify the status is reflected in the user's own feedback view
+        response = auth_client.get('/api/feedback/mine')
+        data = response.get_json()
+        matching = [f for f in data['feedback'] if f['message'] == 'Fix visibility test']
+        assert len(matching) == 1
+        assert matching[0]['status'] == 'Fixed'
+
     def test_update_feedback_invalid_status(self, auth_client):
         response = auth_client.put('/api/feedback/0/status', json={
             'status': 'InvalidStatus'


### PR DESCRIPTION
## Summary
- The "My Feedback" table was not refreshing after an admin changed feedback status (e.g. to "Fixed") via the admin dropdown
- `updateFeedbackStatus()` only called `loadFeedback()` (admin table) but not `loadMyFeedback()` — now it calls both
- Added test to verify status updates persist and are visible through `/api/feedback/mine`

Closes #47

## Test plan
- [ ] As admin, submit feedback, then change its status to "Fixed" in the admin table
- [ ] Verify the "My Feedback" section above immediately reflects the "Fixed" badge (green) without page refresh
- [ ] Verify `pytest tests/ -v` passes (59 passed, 6 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)