### PR TITLE
Fix undefined index variable in admin dev-status dropdown

### DIFF
--- a/backend/templates/update_log.html
+++ b/backend/templates/update_log.html
@@ -970,7 +970,7 @@
                         <td class="${priorityClass}">${fb.priority}</td>
                         <td>${statusCell}</td>
                         <td>
-                            <select class="form-select form-select-sm dev-status-select" data-index="${index}" style="font-size: 0.7rem; padding: 2px 4px; width: auto;">
+                            <select class="form-select form-select-sm dev-status-select" data-index="${idx}" style="font-size: 0.7rem; padding: 2px 4px; width: auto;">
                                 ${devStatusOptions.map(o => `<option value="${o.value}" ${o.value === devStatus ? 'selected' : ''}>${o.label}</option>`).join('')}
                             </select>
                         </td>


### PR DESCRIPTION
## Summary
- Fix `data-index="${index}"` → `data-index="${idx}"` in the admin feedback table's dev-status `<select>` element (line 973 of `update_log.html`)
- The `forEach` callback uses `idx` as its index parameter, but the template literal referenced the undefined `index`, causing dev-status updates to silently fail

Closes #51

## Test plan
- [ ] Open the admin feedback panel on Flies & Swatters page
- [ ] Change a dev-status dropdown value and verify the network request URL contains a valid numeric index (not `undefined`)
- [ ] Confirm the dev-status change persists on page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)