### PR TITLE
Fix combined upload crash on case-mismatched sheet names

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -803,9 +803,10 @@ def _reconcile_special_requests(filename: str, file_type: str) -> int:
 # ============== API Routes ==============
 
 # Known OSO sheet names in combo files (mapped to canonical "RawData")
-_OSO_SHEET_NAMES = {'RawData', 'OSO', 'Open Sales Order', 'Sales Order'}
+# Stored lowercase for case-insensitive matching
+_OSO_SHEET_NAMES = {'rawdata', 'oso', 'open sales order', 'sales order'}
 # Known SDR sheet names in combo files
-_SDR_SHEET_NAMES = {'Sheet1', 'Dispatch Report', 'Shop Dispatch', 'SDR'}
+_SDR_SHEET_NAMES = {'sheet1', 'dispatch report', 'shop dispatch', 'sdr'}
 
 
 def _handle_combined_upload(file, filename):
@@ -818,18 +819,18 @@ def _handle_combined_upload(file, filename):
     file.save(temp_path)
 
     wb = openpyxl.load_workbook(temp_path)
-    sheet_names = set(wb.sheetnames)
+    actual_names = list(wb.sheetnames)
 
-    # Find the OSO and SDR sheets
-    oso_sheet = next((s for s in wb.sheetnames if s in _OSO_SHEET_NAMES), None)
-    sdr_sheet = next((s for s in wb.sheetnames if s in _SDR_SHEET_NAMES), None)
+    # Find the OSO and SDR sheets (case-insensitive)
+    oso_sheet = next((s for s in actual_names if s.lower() in _OSO_SHEET_NAMES), None)
+    sdr_sheet = next((s for s in actual_names if s.lower() in _SDR_SHEET_NAMES), None)
 
     if not oso_sheet and not sdr_sheet:
         wb.close()
         os.unlink(temp_path)
         return jsonify({
             'error': f'Combined file not recognized. Expected sheets like "OSO"/"RawData" '
-                     f'and "Dispatch Report"/"Sheet1", but found: {", ".join(wb.sheetnames)}'
+                     f'and "Dispatch Report"/"Sheet1", but found: {", ".join(actual_names)}'
         }), 400
 
     uploaded = []
@@ -842,8 +843,14 @@ def _handle_combined_upload(file, filename):
         for s in oso_wb.sheetnames:
             if s != oso_sheet:
                 del oso_wb[s]
-        # Rename to RawData for consistency with the parser
-        oso_wb[oso_sheet].title = 'RawData'
+        # Rename to RawData for consistency with the parser.
+        # openpyxl treats sheet names as case-insensitive for collision
+        # detection, so a two-step rename avoids "RawData1" when the
+        # source name differs only by case (e.g. "rawdata" → "RawData").
+        ws = oso_wb[oso_sheet]
+        if ws.title != 'RawData':
+            ws.title = '_tmp_rename_'
+            ws.title = 'RawData'
 
         # Scrub sensitive columns
         ws = oso_wb['RawData']
@@ -952,14 +959,17 @@ def upload_file():
             sensitive_headers = ['unit price', 'net price', 'customer address', 'address']
 
             # Drop all sheets except RawData/OSO (SAP exports include many extra tabs)
-            target_sheet = next((s for s in wb.sheetnames if s in _OSO_SHEET_NAMES), None)
+            target_sheet = next((s for s in wb.sheetnames if s.lower() in _OSO_SHEET_NAMES), None)
             if not target_sheet:
                 wb.close()
                 os.unlink(temp_path)
                 return jsonify({'error': f'Invalid file: expected a "RawData" or "OSO" sheet but found: {", ".join(wb.sheetnames)}'}), 400
             # Rename to RawData for consistency with the parser
+            # Two-step rename avoids openpyxl case-insensitive collision
             if target_sheet != 'RawData':
-                wb[target_sheet].title = 'RawData'
+                ws_target = wb[target_sheet]
+                ws_target.title = '_tmp_rename_'
+                ws_target.title = 'RawData'
                 target_sheet = 'RawData'
             sheets_to_remove = [s for s in wb.sheetnames if s != target_sheet]
             for sheet_name in sheets_to_remove:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -312,3 +312,72 @@ class TestFileHotListEndpoint:
         """Unauthenticated access should be redirected."""
         response = client.get('/api/planner/file-hot-list')
         assert response.status_code in (302, 401)
+
+
+class TestCombinedUpload:
+    """Tests for combined OSO+SDR file upload (GH #46)."""
+
+    def _make_combined_xlsx(self, oso_sheet_name, sdr_sheet_name):
+        """Create a minimal combined xlsx in memory with given sheet names."""
+        import io
+        import openpyxl
+        wb = openpyxl.Workbook()
+        # Rename default sheet to the OSO name
+        ws_oso = wb.active
+        ws_oso.title = oso_sheet_name
+        ws_oso.append(['Order', 'Description'])
+        ws_oso.append(['WO-001', 'Test Stator'])
+        # Add SDR sheet
+        ws_sdr = wb.create_sheet(title=sdr_sheet_name)
+        ws_sdr.append(['Order', 'Operation'])
+        ws_sdr.append(['WO-001', '100'])
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+        return buf
+
+    def test_combined_upload_standard_names(self, auth_client):
+        """Combined file with standard sheet names should succeed."""
+        data = self._make_combined_xlsx('RawData', 'Sheet1')
+        response = auth_client.post('/api/upload', data={
+            'file': (data, 'COMB_Report.xlsx'),
+            'type': 'combined_report',
+        }, content_type='multipart/form-data')
+        assert response.status_code == 200
+        result = response.get_json()
+        assert result['success'] is True
+        assert len(result['split_into']) == 2
+
+    def test_combined_upload_case_insensitive(self, auth_client):
+        """Combined file with differently-cased sheet names should succeed."""
+        data = self._make_combined_xlsx('rawdata', 'sheet1')
+        response = auth_client.post('/api/upload', data={
+            'file': (data, 'COMB_Report.xlsx'),
+            'type': 'combined_report',
+        }, content_type='multipart/form-data')
+        assert response.status_code == 200
+        result = response.get_json()
+        assert result['success'] is True
+        assert len(result['split_into']) == 2
+
+    def test_combined_upload_uppercase_names(self, auth_client):
+        """Combined file with uppercase sheet names should succeed."""
+        data = self._make_combined_xlsx('OSO', 'SDR')
+        response = auth_client.post('/api/upload', data={
+            'file': (data, 'COMB_Report.xlsx'),
+            'type': 'combined_report',
+        }, content_type='multipart/form-data')
+        assert response.status_code == 200
+        result = response.get_json()
+        assert result['success'] is True
+
+    def test_combined_upload_unrecognized_sheets(self, auth_client):
+        """Combined file with unknown sheet names should return 400."""
+        data = self._make_combined_xlsx('FooBar', 'BazQux')
+        response = auth_client.post('/api/upload', data={
+            'file': (data, 'COMB_Report.xlsx'),
+            'type': 'combined_report',
+        }, content_type='multipart/form-data')
+        assert response.status_code == 400
+        result = response.get_json()
+        assert 'not recognized' in result['error']


### PR DESCRIPTION
## Summary
- Combined OSO+SDR upload failed when Excel sheet tab names had different casing (e.g. "rawdata" vs "RawData")
- Sheet name detection was case-sensitive, causing valid combined files to be rejected
- openpyxl's case-insensitive collision detection caused a secondary crash when renaming sheets that differ only by case (producing "RawData1" instead of "RawData")
- Both combined and standalone OSO upload handlers are now case-insensitive with a two-step rename workaround

Closes #46

## Test plan
- [x] New test: standard sheet names (RawData/Sheet1) upload successfully
- [x] New test: lowercase sheet names (rawdata/sheet1) upload successfully
- [x] New test: uppercase alternate names (OSO/SDR) upload successfully
- [x] New test: unrecognized sheet names return 400 error
- [x] Full test suite passes (62 passed, 1 pre-existing failure in feedback test isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)