### PR TITLE
fix(scheduler): rotor exclusion, obsolete-rubber routing, injection buffer knob + diagnostic harness

### DIFF
--- a/backend/algorithms/des_scheduler.py
+++ b/backend/algorithms/des_scheduler.py
@@ -543,6 +543,14 @@ def create_injection_machines() -> List[InjectionMachine]:
     ]
 
 
+# Rubber types the Desma injection line can actually run. Anything else in the
+# core mapping (XP, 1A, NED1, HN-SR, ...) is treated as obsolete/bad data: such
+# orders are routed to pending with a reason for planner validation instead of
+# being fed to the blast loop (where an unrunnable rubber type can never clear
+# the injection-bottleneck check and would burn empty takt slots indefinitely).
+VALID_INJECTION_RUBBER = {"HR", "XE", "XR", "XD"}
+
+
 # =============================================================================
 # STATION
 # =============================================================================
@@ -708,7 +716,8 @@ class DESScheduler:
                  core_inventory: Dict, operations: Dict = None,
                  work_schedule: Any = None, working_days: List[int] = None,
                  shift_hours: int = 12, day_configs: Dict = None,
-                 takt_time_minutes: int = 30, wip_orders: List[Dict] = None):
+                 takt_time_minutes: int = 30, wip_orders: List[Dict] = None,
+                 injection_buffer_hours: float = 0.5):
         """
         Initialize the DES scheduler.
 
@@ -727,6 +736,11 @@ class DESScheduler:
         """
         self.orders = orders
         self.wip_orders = wip_orders or []
+        # Max acceptable wait (hours) at injection before a blast is deferred.
+        # Represents the realistic WIP buffer allowed to queue in front of the
+        # Desma line. 0.5h was pathologically tight (collapsed near-term to ~5/day);
+        # tune to match real sustained throughput (~50-60 blasts/day, both shifts).
+        self.injection_buffer_hours = injection_buffer_hours
         self.core_mapping = core_mapping
         self.core_inventory = self._init_core_inventory(core_inventory)
         self.operations = operations or {}
@@ -1089,11 +1103,11 @@ class DESScheduler:
             # No machine can run this rubber type at all
             return True, None
 
-        # A machine is available — check if it would cause significant delay
-        # Bottleneck = the part would have to wait more than 1 takt period (30 min)
-        # for injection after arriving at the injection station
+        # A machine is available — check if it would cause significant delay.
+        # Bottleneck = the part would wait longer than the acceptable injection
+        # queue buffer after arriving at the injection station.
         wait_time = (best_available - est_arrival).total_seconds() / 3600
-        if wait_time > 0.5:  # More than 30 min wait = bottleneck
+        if wait_time > self.injection_buffer_hours:  # acceptable injection queue exceeded
             return True, None
 
         return False, best_machine_id
@@ -1243,11 +1257,23 @@ class DESScheduler:
                     'core_number_needed': core_number
                 })
             else:
-                schedulable.append({
-                    'order': order,
-                    'core_number': core_number,
-                    'part_data': part_data
-                })
+                # Core exists — but if the part's rubber type isn't runnable on
+                # any injection machine, it can never be scheduled. Surface it as
+                # pending (for PN validation) rather than stalling the blast loop.
+                rb = part_data.get('rubber_type') if part_data else None
+                rb_str = str(rb).strip().upper() if rb is not None else ''
+                if rb_str and rb_str != 'NAN' and rb_str not in VALID_INJECTION_RUBBER:
+                    pending.append({
+                        **order,
+                        'reason': f'Invalid/obsolete rubber type "{rb}" — no injection machine runs it (validate PN)',
+                        'core_number_needed': core_number
+                    })
+                else:
+                    schedulable.append({
+                        'order': order,
+                        'core_number': core_number,
+                        'part_data': part_data
+                    })
 
         return schedulable, pending
 
@@ -1559,7 +1585,9 @@ class DESScheduler:
                     current_slot, takt_minutes / 60.0
                 )
             elif all_blocked_by_bottleneck:
-                # All orders have cores but injection is full — skip one takt slot
+                # All remaining orders have cores but injection is full — advance
+                # one takt slot. The acceptable backlog is governed by
+                # self.injection_buffer_hours (see _check_injection_bottleneck).
                 consecutive_empty += 1
                 if consecutive_empty >= max_empty_slots:
                     print(f"[WARN] Scheduling stopped: {consecutive_empty} consecutive "

--- a/backend/parsers/order_filters.py
+++ b/backend/parsers/order_filters.py
@@ -114,8 +114,15 @@ def should_exclude_order(part_number: Optional[str], description: Optional[str],
     if desc_upper.startswith('STATOR, CUSTOMER'):
         return 'Stator Customer'
 
-    # Exclude rotors: R/C prefix (e.g., R/C1234, RC1234) or standalone C/R + digit (e.g., C675678, R800783)
+    # Exclude rotors. Two cases:
+    #  1. Part number with R/C prefix (e.g., R/C1234, RC1234, C675678, R800783)
+    #  2. Numeric (new-part-number) rotors whose ROTOR nature only shows in the
+    #     description: a leading "R<digit>" designation (R8257810.0-...) or the
+    #     "-SLD" solid-rotor marker (e.g. ...HR-SLD-2.125, ...FWC-SLD-API NC40).
+    #     Stators/relines descriptions lead with "S<digit>" and never carry -SLD.
     if re.match(r'^[RC]\d', part_upper) or re.match(r'^R/?C\d', part_upper):
+        return 'Rotor'
+    if re.match(r'^R\d', desc_upper) or '-SLD' in desc_upper:
         return 'Rotor'
 
     # Exclude bearings (not stators)

--- a/memory.md
+++ b/memory.md
@@ -1,7 +1,45 @@
 # DDSchedulerBot / DynaBot — Session Memory
 
-**Last updated:** March 8, 2026
-**Current deployed version:** MVP 2.0.0 (on master + dev, deployed to Cloud Run)
+**Last updated:** June 24, 2026
+**Current deployed version:** MVP 2.0.5 (CLAUDE.md); engine investigation on branch `fix/scheduler-undersched-diag`
+
+---
+
+## Session: June 2026 — Scheduler under-scheduling / wrong-timing investigation
+
+**Symptom:** today's run (5day/12h, OSO/SDR 06-22) put only ~40 blasts in 2 days (Sean expects 60–70),
+456 orders Unscheduled, big late "clump." Built offline harness `tools/local_run.py` (no Flask/GCS;
+point `--data-dir` at a folder of inputs) — reproduces live output exactly (422 sched / 456 unsched).
+
+**Root-cause decomposition (was MOSTLY data/config, NOT engine bugs):**
+- 174 parts not in core mapping (183/199 numeric; genuine absence, not format) → no core → unscheduled.
+- 152 orders with rubber type no Desma runs (XP 121, 1A, NED1, blank). Only **HR/XE/XR/XD valid**;
+  XP/1A/NED1 are obsolete-PN/bad data (Sean to validate — exceptions workbook delivered).
+- 74 rotors (`R…/-SLD` descriptions, numeric PNs) leaking past the exclusion filter.
+- Stale core mapping was a RED HERRING (524→529 cores w/ fresh). Takt + changeovers also red herrings
+  (engine plans **0** changeovers; machine-selection already avoids them).
+
+**Fixes landed (verified, tests 56 pass):** rotor exclusion via description (`order_filters.py`);
+invalid-rubber orders routed to pending w/ reason (`des_scheduler._classify_orders`);
+`injection_buffer_hours` knob (default 0.5 = no change; ≥2 clears a 33-order stall + 500-empty-slot stop).
+
+**THE UNSOLVED CORE PROBLEM (next session — injection redesign):** near-term collapses to ~5/day and
+CANNOT be tuned out via takt/buffer/changeovers. Proven: bottleneck-OFF → 96/2days, ON → 30; tuning
+buffer/takt stays pinned at ~29. Cause = injection-admission ARCHITECTURE: blast admission gates on a
+machine reservation using a 3.85h **working-time** lead (`_estimate_injection_arrival` via advance_time)
+mixed with wall-clock machine bookings (`_reserve_injection_machine` uses raw timedelta) → day-1 arrivals
+collapse into one window injection can't drain. Real capacity ≈ 50–60/day (both shifts, 25–30/shift;
+3 machines/rubber ÷ 0.8–1.5h inj time). **Fix = model injection as a true capacity-limited station**
+(likely in the event-loop sim, not the blast-admission heuristic). Key spots: `_check_injection_bottleneck`
+/ `_reserve_injection_machine` / `_estimate_injection_arrival` (des_scheduler.py ~1036-1127),
+blast loop `_schedule_blast_arrivals` (~1395-1620).
+
+**Data actions for Sean:** validate 152 obsolete-PN list; add ~125 missing stators to mapping; upload
+fresh Core Mapping to prod via app (prod reads GCS, not the repo copy). Local feedback test store
+(`data/state/user_feedback.json`, not git-tracked) has old March test data → 1 local feedback test fails;
+prod GCS unaffected.
+
+---
 
 ---
 

--- a/tools/local_run.py
+++ b/tools/local_run.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Local offline diagnostic harness for the DES scheduler.
+
+Runs DataLoader + DESScheduler entirely offline (no Flask, no GCS) against a
+directory of input files, mirroring how app._run_schedule_mode builds and runs
+the scheduler. Prints diagnostic metrics: order counts, unscheduled breakdown,
+blasts-per-day histogram, core-inventory stats, and parts with no mapping hit.
+
+Usage:
+    python tools/local_run.py --data-dir /path/to/inputs [--mode 5day_12h] [--no-hot-list]
+
+The data dir should contain one of each input type (most-recent of each pattern
+is used): OSO*/Open Sales Order*, SDR*/Shop Dispatch*, Core Mapping*/Core_Mapping*,
+HOT LIST*, DCPReport*.
+"""
+import argparse
+import os
+import sys
+from collections import Counter
+from datetime import datetime
+
+# Wire backend onto sys.path (same as des_scheduler.__main__)
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BACKEND = os.path.join(REPO_ROOT, 'backend')
+sys.path.insert(0, BACKEND)
+
+from data_loader import DataLoader                       # noqa: E402
+from algorithms.des_scheduler import DESScheduler        # noqa: E402
+
+MODES = {
+    '4day_10h': ([0, 1, 2, 3], 10),
+    '4day_12h': ([0, 1, 2, 3], 12),
+    '5day_12h': ([0, 1, 2, 3, 4], 12),
+    '6day_12h': ([0, 1, 2, 3, 4, 5], 12),
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--data-dir', required=True, help='Directory of input files')
+    ap.add_argument('--mode', default='5day_12h', choices=MODES.keys())
+    ap.add_argument('--no-hot-list', action='store_true', help='Skip hot list (baseline only)')
+    ap.add_argument('--takt', type=int, default=30, help='Takt time in minutes (default 30)')
+    ap.add_argument('--inj-buffer', type=float, default=0.5, help='Injection queue buffer hours (default 0.5)')
+    ap.add_argument('--start', default=None, help='Start date YYYY-MM-DD (default: engine decides)')
+    ap.add_argument('--sample-unsched', type=int, default=0, help='Print N sample unscheduled orders')
+    args = ap.parse_args()
+
+    working_days, shift_hours = MODES[args.mode]
+    start_date = datetime.strptime(args.start, '%Y-%m-%d').replace(hour=5, minute=30) if args.start else None
+
+    print(f"\n{'#'*72}\n# LOCAL RUN  dir={args.data_dir}  mode={args.mode}\n{'#'*72}")
+
+    loader = DataLoader(data_dir=args.data_dir)
+    if not loader.load_all():
+        print("[FATAL] loader.load_all() returned False")
+        sys.exit(1)
+
+    # --- Core mapping / inventory stats (the suspected lever) ---
+    total_cores = sum(len(c) for c in loader.core_inventory.values())
+    multi = sum(1 for c in loader.core_inventory.values() if len(c) > 1)
+    print(f"\n[CORE DATA] part->core mappings: {len(loader.core_mapping)}")
+    print(f"[CORE DATA] unique core numbers: {len(loader.core_inventory)}  "
+          f"| total physical cores (suffixes): {total_cores}  | numbers w/ >1 core: {multi}")
+
+    # Parts in orders with no mapping hit
+    no_map = [o for o in loader.orders
+              if o.get('part_number') and o.get('part_number') not in loader.core_mapping]
+    print(f"[CORE DATA] parsed orders with NO core-mapping hit: {len(no_map)} / {len(loader.orders)}")
+
+    # --- Build + run scheduler (mirror app._run_schedule_mode) ---
+    def build():
+        return DESScheduler(
+            orders=loader.orders,
+            core_mapping=loader.core_mapping,
+            core_inventory=loader.core_inventory,
+            working_days=working_days,
+            shift_hours=shift_hours,
+            wip_orders=loader.wip_in_process_orders,
+            takt_time_minutes=args.takt,
+            injection_buffer_hours=args.inj_buffer,
+        )
+
+    scheduler = build()
+    if args.no_hot_list or not loader.hot_list_entries:
+        scheduled = scheduler.schedule_orders(start_date=start_date)
+        active = scheduler
+    else:
+        scheduled = scheduler.schedule_orders(start_date=start_date)  # baseline (discarded)
+        active = build()
+        scheduled = active.schedule_orders(start_date=start_date, hot_list_entries=loader.hot_list_entries)
+
+    # --- Metrics ---
+    sched_wo = {o.wo_number for o in scheduled}
+    unscheduled = [o for o in loader.orders if o.get('wo_number') not in sched_wo]
+    with_blast = [o for o in scheduled if o.blast_date]
+
+    print(f"\n{'='*72}\nRESULTS ({args.mode})\n{'='*72}")
+    print(f"  parsed orders      : {len(loader.orders)}")
+    print(f"  WIP in-process     : {len(loader.wip_in_process_orders)}")
+    print(f"  scheduled          : {len(scheduled)}")
+    print(f"  with blast date    : {len(with_blast)}")
+    print(f"  UNSCHEDULED        : {len(unscheduled)}")
+    print(f"  pending core       : {len(getattr(active, 'pending_core_orders', []))}")
+
+    # Blasts-per-day histogram + near-term fill
+    by_day = Counter(o.blast_date.date() for o in with_blast)
+    days = sorted(by_day)
+    print(f"\n  blast span: {days[0] if days else '-'} .. {days[-1] if days else '-'}  "
+          f"({len(days)} distinct days)")
+    if days:
+        first2 = sum(by_day[d] for d in days[:2])
+        print(f"  >>> first 2 working days fill: {first2}  (target ~60-70)")
+        print("  per-day histogram:")
+        for d in days:
+            bar = '#' * min(by_day[d], 60)
+            print(f"     {d}  {by_day[d]:3d}  {bar}")
+
+    if args.sample_unsched and unscheduled:
+        print(f"\n  sample unscheduled (first {args.sample_unsched}):")
+        for o in unscheduled[:args.sample_unsched]:
+            print(f"     WO {o.get('wo_number')} | {o.get('part_number')} | "
+                  f"op {o.get('current_operation')} | mapped={o.get('part_number') in loader.core_mapping}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Why
Investigation into the scheduler under-scheduling (456 orders Unscheduled, ~40 blasts in the first 2 days vs. the 60–70 expected, plus a large late "clump"). Built an offline harness that reproduces the live output exactly, then decomposed the cause.

## Key finding
The "456 unscheduled" was **mostly data/config, not engine bugs**:
- **174** parts not in the core mapping (genuine absence, not a format mismatch)
- **152** orders with a rubber type no Desma runs (XP/1A/NED1/blank — obsolete PNs / bad data; only HR/XE/XR/XD are valid)
- **74** rotors leaking past the exclusion filter
- only **~52** were genuine engine scheduling failures

Stale core mapping was a red herring (524→529 physical cores with the fresh file). Takt and changeovers were also red herrings (the engine plans **0** changeovers).

## What this PR changes
- **Rotor exclusion via description** (`order_filters.py`): catches numeric-PN rotors (`R<digit>` / `-SLD`) that the part-number-only rule missed (−74 in today's data).
- **Obsolete-rubber routing** (`des_scheduler._classify_orders`): orders whose rubber type isn't runnable on any Desma go to *pending with a reason* instead of stalling the blast loop on 500 empty takt slots (stall population 163→33).
- **Tunable `injection_buffer_hours`** (`des_scheduler`): default `0.5` preserves current behavior; `≥2` clears the residual 33-order stall (500→533 scheduled). Replaces a hardcoded `0.5h` threshold.
- **`tools/local_run.py`**: reusable offline diagnostic harness (no Flask/GCS).
- Session findings recorded in `memory.md`.

## NOT in this PR (next focused session)
The core "60–70 in 2 days" gap is the **injection-admission architecture** — near-term collapses to ~5/day and can't be tuned out (proven: bottleneck OFF → 96/2days, ON → 30, buffer/takt sweeps pinned at ~29). It needs a redesign of injection as a true capacity-limited station. Details in `memory.md`.

## Testing
- `pytest tests/ -k "not feedback"` → **56 passed, 6 skipped** (feedback tests excluded due to a pre-existing local test-store data issue, unrelated to these changes).
- Harness reproduces the live 422-scheduled / 456-unscheduled baseline; fixes verified against today's real OSO/SDR.

## Follow-ups for the product owner
- Validate the 152 obsolete-PN list (delivered as a workbook).
- Add ~125 missing stators to the core mapping.
- Upload the fresh Core Mapping to prod via the app (prod reads GCS, not the repo copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)